### PR TITLE
Solucionados algunos bugs de facturas

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -45,7 +45,7 @@ function App() {
     const fechaHoy = DateTime.local();
     const fechaVencimiento = DateTime.fromMillis(+vencimiento);
     const diferenciaFechas = fechaVencimiento.diff(fechaHoy, "days").toObject();
-    if (verificaVencimiento(fechaHoy, fechaVencimiento)) {
+    if (verificaVencimiento(vencimiento)) {
       return `${fechaVencimiento.setLocale("es").toLocaleString()} \
       (faltan ${Math.ceil(diferenciaFechas.days)} días)`;
     } else {

--- a/src/componentes/Factura.js
+++ b/src/componentes/Factura.js
@@ -11,7 +11,7 @@ const Factura = (props) => {
       <td><span className="base">{factura.base}</span>€</td>
       <td><span
         className="cantidad-iva"
-      >{factura.tipoIva}</span>€ (<span className="tipo-iva"></span>%)</td>
+      >{factura.base * factura.tipoIva / 100}</span>€ (<span className="tipo-iva"></span>%)</td>
       <td><span className="total">{factura.base * (1 + factura.tipoIva / 100)}</span>€</td>
       <td
         className={`estado${factura.abonada ? " table-success" : " table-danger"}`}


### PR DESCRIPTION
El IVA mostraba 21 siempre porque no se estaba multiplicando por base, y al cambiar unos parámetros de verificaVencimiento los días que hacía oa faltaba para el vencimiento también salían mal